### PR TITLE
parse Integer (%d %ld %u %lu %llu) should be precise for octal

### DIFF
--- a/lib/scanf.js
+++ b/lib/scanf.js
@@ -101,15 +101,19 @@ var getInteger = function(pre, next) {
   var text = getInput(pre, next, '[-]?[A-Za-z0-9]+');
   if (!text) {
     return null;
-  } else if (text[0] == '0') {
-    if (text[1] == 'x' || text[1] == 'X') {
-      return utils.hex2int(text);
-    } else {
-      return utils.octal2int(text);
-    }
-  } else {
-    return parseInt(text);
   }
+  if (text.length > 2) {
+    if (text[0] === '0') {
+      if (text[1].toLowerCase() === 'x') {
+        return utils.hex2int(text);
+      }
+      // parse Integer (%d %ld %u %lu %llu) should be precise for octal
+      if (text[1].toLowerCase() === 'o') {
+        return utils.octal2int(text);
+      }
+    }
+  }
+  return parseInt(text);
 };
 
 var getFloat = function(pre, next) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,9 +11,9 @@ var ASCII = {
 };
 
 exports.hex2int = function(str) {
+  str = str.replace(/^[0Oo][Xx]/, '');
   var ret = 0,
     digit = 0;
-  str = str.replace(/^[0O][Xx]/, '');
 
   for (var i = str.length - 1; i >= 0; i--) {
     var num = intAtHex(str[i], digit++);
@@ -54,7 +54,7 @@ var intAtHex = function(c, digit) {
 };
 
 exports.octal2int = function(str) {
-  str = str.replace(/^0/, '');
+  str = str.replace(/^0[Oo]?/, '');
   var ret = 0,
     digit = 0;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,7 @@ var ASCII = {
   A: 'A'.charCodeAt(),
   F: 'F'.charCodeAt(),
   0: '0'.charCodeAt(),
-  8: '8'.charCodeAt(),
+  7: '7'.charCodeAt(),
   9: '9'.charCodeAt(),
 };
 
@@ -77,7 +77,7 @@ var intAtOctal = function(c, digit) {
   var num = null;
   var ascii = c.charCodeAt();
 
-  if (ascii >= ASCII[0] && ascii <= ASCII[8]) {
+  if (ascii >= ASCII[0] && ascii <= ASCII[7]) {
     num = ascii - ASCII[0];
   } else {
     if (THROW) {

--- a/test/int.js
+++ b/test/int.js
@@ -124,18 +124,6 @@ describe('scanf', function() {
       done();
     });
 
-    it('[hex=%d] \tshould get a integer number from hex', function(done) {
-      var num = sscanf('hex=0x10', 'hex=%d');
-      should.strictEqual(num, 16);
-      done();
-    });
-
-    it('[octal=%d] \tshould get a integer number from octal', function(done) {
-      var num = sscanf('octal=010', 'octal=%d');
-      should.strictEqual(num, 8);
-      done();
-    });
-
     it('[%d%d] \t\tshould get an array with two integers [5, 6]', function(done) {
       var num = sscanf('5,6', '%d%d');
       should.deepEqual(num, [5, 6]);
@@ -189,5 +177,55 @@ describe('scanf', function() {
       should.deepEqual(num, [-5, null]);
       done();
     });
+
+    // starts of '0' and not following with 'o' or 'O' or 'x' or 'X' is decimal for %d %ld %u %lu %llu
+    it('[%d] \t\tshould get a integer number 8 from 08', function(done) {
+      var num = sscanf('08', '%d');
+      should.strictEqual(num, 8);
+      done();
+    });
+
+    // starts of '0' and not following with 'o' or 'O' or 'x' or 'X' is decimal for %d %ld %u %lu %llu
+    it('[%d] \t\tshould get a integer number 9 from 09', function(done) {
+      var num = sscanf('09', '%d');
+      should.strictEqual(num, 9);
+      done();
+    });
+
+    // starts of '0' and not following with 'o' or 'O' or 'x' or 'X' is decimal for %d %ld %u %lu %llu
+    it('[%d] \t\tshould get a integer number 12 from 012', function(done) {
+      var num = sscanf('012', '%d');
+      should.strictEqual(num, 12);
+      done();
+    });
+
+    // starts of '0o' or '0O' is octal for %d %ld %u %lu %llu
+    it('[octal=%d] \t\tshould get a integer number 11 from 0o13', function(done) {
+      var num = sscanf('0o13', '%d');
+      should.strictEqual(num, 11);
+      done();
+    });
+
+    // starts of '0o' or '0O' is octal for %d %ld %u %lu %llu
+    it('[octal=%d] \t\tshould get a integer number 12 from 0O14', function(done) {
+      var num = sscanf('0O14', '%d');
+      should.strictEqual(num, 12);
+      done();
+    });
+
+    // starts of '0x' or '0X' is hex for %d %ld %u %lu %llu
+    it('[hex=%d] \t\tshould get a integer number 21 from 0x15', function(done) {
+      var num = sscanf('0x15', '%d');
+      should.strictEqual(num, 21);
+      done();
+    });
+
+    // starts of '0x' or '0X' is hex for %d %ld %u %lu %llu
+    it('[hex=%d] \t\tshould get a integer number 26 from 0X1A', function(done) {
+      var num = sscanf('0X1A', '%d');
+      should.strictEqual(num, 26);
+      done();
+    });
+
   });
 });


### PR DESCRIPTION
test/int.js allow the following testing cases to work
``` text
[%d] should get a integer number 8 from 08
[%d] should get a integer number 9 from 09
[%d] should get a integer number 12 from 012
[octal=%d] should get a integer number 11 from 0o13
[octal=%d] should get a integer number 12 from 0O14
[hex=%d] should get a integer number 21 from 0x15
[hex=%d] should get a integer number 26 from 0X1A
```
 test/int.js remove the following testing cases
``` text
[hex=%d] should get a integer number from hex
[octal=%d] should get a integer number from octal
```