### PR TITLE
Remove circular dependency & return NaN for invalid hexadecimals and …

### DIFF
--- a/lib/scanf.js
+++ b/lib/scanf.js
@@ -117,11 +117,25 @@ var getInteger = function(pre, next) {
   if (text.length > 2) {
     if (text[0] === '0') {
       if (text[1].toLowerCase() === 'x') {
-        return utils.hex2int(text);
+        try {
+          return utils.hex2int(text);
+        }
+        catch(e) {
+          if(exports.throw) return NaN
+
+          return null
+        }
       }
       // parse Integer (%d %ld %u %lu %llu) should be precise for octal
       if (text[1].toLowerCase() === 'o') {
-        return utils.octal2int(text);
+        try {
+          return utils.octal2int(text);
+        }
+        catch(e) {
+          if(exports.throw) return NaN
+
+          return null
+        }
       }
     }
   }
@@ -158,12 +172,26 @@ var getHexFloat = function(pre, next) {
 
 var getHex = function(pre, next) {
   var text = getInput(pre, next, '[A-Za-z0-9]+');
-  return utils.hex2int(text);
+  try {
+    return utils.hex2int(text);
+  }
+  catch(e) {
+    if(exports.throw) return NaN
+
+    return null
+  }
 };
 
 var getOctal = function(pre, next) {
   var text = getInput(pre, next, '[A-Za-z0-9]+');
-  return utils.octal2int(text);
+  try {
+    return utils.octal2int(text);
+  }
+  catch(e) {
+    if(exports.throw) return NaN
+
+    return null
+  }
 };
 
 var getString = function(pre, next) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,3 @@
-var THROW = require('./scanf').throw;
-
 var ASCII = {
   a: 'a'.charCodeAt(),
   f: 'f'.charCodeAt(),
@@ -16,15 +14,7 @@ exports.hex2int = function(str) {
     digit = 0;
 
   for (var i = str.length - 1; i >= 0; i--) {
-    var num = intAtHex(str[i], digit++);
-    if (num !== null) {
-      ret += num;
-    } else {
-      if (THROW) {
-        throw new Error('Invalid hex ' + str);
-      }
-      return null;
-    }
+    ret += intAtHex(str[i], digit++);
   }
 
   return ret;
@@ -41,10 +31,7 @@ var intAtHex = function(c, digit) {
   } else if (ASCII[0] <= ascii && ascii <= ASCII[9]) {
     ret = ascii - ASCII[0];
   } else {
-    if (THROW) {
-      throw new Error('Invalid ascii [' + c + ']');
-    }
-    return null;
+    throw new Error('Invalid ascii [' + c + ']');
   }
 
   while (digit--) {
@@ -59,15 +46,7 @@ exports.octal2int = function(str) {
     digit = 0;
 
   for (var i = str.length - 1; i >= 0; i--) {
-    var num = intAtOctal(str[i], digit++);
-    if (num !== null) {
-      ret += num;
-    } else {
-      if (THROW) {
-        throw new Error('Invalid octal ' + str);
-      }
-      return null;
-    }
+    ret += intAtOctal(str[i], digit++);
   }
 
   return ret;
@@ -80,10 +59,7 @@ var intAtOctal = function(c, digit) {
   if (ascii >= ASCII[0] && ascii <= ASCII[7]) {
     num = ascii - ASCII[0];
   } else {
-    if (THROW) {
-      throw new Error('Invalid char to Octal [' + c + ']');
-    }
-    return null;
+    throw new Error('Invalid char to Octal [' + c + ']');
   }
 
   while (digit--) {

--- a/test/hex.js
+++ b/test/hex.js
@@ -21,9 +21,9 @@ describe('scanf', function() {
       done();
     });
 
-    it('[%x] \t\tinvalid hex number should get a null', function(done) {
+    it('[%x] \t\tinvalid hex number should get NaN', function(done) {
       var num = sscanf('0x1G0', '%x');
-      should.strictEqual(num, null);
+      num.should.be.eql(NaN);
       done();
     });
 

--- a/test/octal.js
+++ b/test/octal.js
@@ -21,9 +21,9 @@ describe('scanf', function() {
       done();
     });
 
-    it('[%o] \t\tinvalid hex number should get a null', function(done) {
+    it('[%o] \t\tinvalid hex number should get NaN', function(done) {
       var num = sscanf('0190', '%o');
-      should.strictEqual(num, null);
+      num.should.be.eql(NaN);
       done();
     });
 


### PR DESCRIPTION
…octals

This fixes #31. In addition to that, it gives an homogeneous output for invalid hexadecimal and octals numbers, similar to integer and floats ones.

I've also seen exceptions are not being processed at all, so probably instead of `exports.throw` flag should be names something like `returnNaN` or something similar, what do you think?