### PR TITLE
Support Android platform

### DIFF
--- a/lib/gets.js
+++ b/lib/gets.js
@@ -12,7 +12,9 @@ module.exports = function() {
   var fd =
     'win32' === process.platform
       ? process.stdin.fd
-      : fs.openSync('/dev/stdin', 'rs');
+      : 'android' === process.platform 
+        ? fs.openSync('/proc/self/fd/0', 'rs')
+        : fs.openSync('/dev/stdin', 'rs');
   bytesRead = 0;
 
   try {


### PR DESCRIPTION
Android platform have no '/dev/stdin', use '/proc/self/fd/0' for it.