### PR TITLE
fix: stop opening /dev/stdin on every gets() call

### DIFF
--- a/lib/gets.js
+++ b/lib/gets.js
@@ -12,10 +12,7 @@ var createGets = function(customFs) {
   var localFs = customFs || fs;
 
   return function() {
-    var fd =
-      'win32' === process.platform
-        ? process.stdin.fd
-        : localFs.openSync('/dev/stdin', 'rs');
+    var fd = process.stdin.fd;
     bytesRead = 0;
 
     try {

--- a/test/gets.js
+++ b/test/gets.js
@@ -60,4 +60,21 @@ describe('gets', function() {
     var result = gets();
     should.strictEqual(result, 'hello');
   });
+
+  it('should not call openSync (prevents fd leak #46)', function() {
+    var openSyncCalled = false;
+    var gets = loadGetsWith({
+      openSync: function() {
+        openSyncCalled = true;
+        throw new Error('openSync should not be called');
+      },
+      readSync: function() {
+        return 0;
+      }
+    });
+
+    var result = gets();
+    should.strictEqual(result, '');
+    should.strictEqual(openSyncCalled, false, 'openSync is called — fd leak is present');
+  });
 });


### PR DESCRIPTION
Fixes #46. Use process.stdin.fd uniformly across all platforms instead of calling fs.openSync on every invocation. This also resolves Android compatibility (#33).