### PR TITLE
ci: add Windows and macOS to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           - "20.x"
           - "22.x"
         include:
-          # EOL versions tested on ubuntu + windows (engines: ">= 4")
           - os: ubuntu-latest
             node-version: "4.x"
           - os: ubuntu-latest
@@ -44,8 +43,19 @@ jobs:
             node-version: "10.x"
           - os: windows-latest
             node-version: "12.x"
+          - os: macos-13
+            node-version: "4.x"
+          - os: macos-13
+            node-version: "6.x"
+          - os: macos-13
+            node-version: "8.x"
+          - os: macos-13
+            node-version: "10.x"
+          - os: macos-13
+            node-version: "12.x"
+          - os: macos-13
+            node-version: "14.x"
         exclude:
-          # Node 14 has no prebuilt binary for macOS arm64
           - os: macos-latest
             node-version: "14.x"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,26 @@ name: CI
 
 on:
   push:
-    branches: [ "work", "master", "main" ]
+    branches: ["master", "main"]
   pull_request:
 
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["4.x", "6.x", "8.x", "10.x", "12.x", "14.x", "16.x", "18.x", "20.x"]
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        node-version:
+          - "14.x"
+          - "16.x"
+          - "18.x"
+          - "20.x"
+          - "22.x"
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,20 @@ jobs:
           - "18.x"
           - "20.x"
           - "22.x"
+        include:
+          # EOL versions tested on ubuntu only (engines: ">= 4")
+          - os: ubuntu-latest
+            node-version: "4.x"
+          - os: ubuntu-latest
+            node-version: "6.x"
+          - os: ubuntu-latest
+            node-version: "8.x"
+          - os: ubuntu-latest
+            node-version: "10.x"
+          - os: ubuntu-latest
+            node-version: "12.x"
         exclude:
+          # Node 14 has no prebuilt binary for macOS arm64
           - os: macos-latest
             node-version: "14.x"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           - "18.x"
           - "20.x"
           - "22.x"
+        exclude:
+          - os: macos-latest
+            node-version: "14.x"
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,19 +43,8 @@ jobs:
             node-version: "10.x"
           - os: windows-latest
             node-version: "12.x"
-          - os: macos-13
-            node-version: "4.x"
-          - os: macos-13
-            node-version: "6.x"
-          - os: macos-13
-            node-version: "8.x"
-          - os: macos-13
-            node-version: "10.x"
-          - os: macos-13
-            node-version: "12.x"
-          - os: macos-13
-            node-version: "14.x"
         exclude:
+          # Node 14 has no prebuilt binary for macOS arm64
           - os: macos-latest
             node-version: "14.x"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - "20.x"
           - "22.x"
         include:
-          # EOL versions tested on ubuntu only (engines: ">= 4")
+          # EOL versions tested on ubuntu + windows (engines: ">= 4")
           - os: ubuntu-latest
             node-version: "4.x"
           - os: ubuntu-latest
@@ -33,6 +33,16 @@ jobs:
           - os: ubuntu-latest
             node-version: "10.x"
           - os: ubuntu-latest
+            node-version: "12.x"
+          - os: windows-latest
+            node-version: "4.x"
+          - os: windows-latest
+            node-version: "6.x"
+          - os: windows-latest
+            node-version: "8.x"
+          - os: windows-latest
+            node-version: "10.x"
+          - os: windows-latest
             node-version: "12.x"
         exclude:
           # Node 14 has no prebuilt binary for macOS arm64

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Do you want a `sscanf` like function to parse format strings?
 npm install scanf
 ```
 
+## CI
+
+The project is tested on GitHub Actions across the following platforms:
+
+| OS       | Node.js versions              |
+|----------|-------------------------------|
+| Ubuntu   | 4.x ~ 22.x                    |
+| Windows  | 4.x ~ 22.x                    |
+| macOS    | 16.x ~ 22.x (arm64)           |
+
+> macOS CI only covers Node.js 16+ because the latest macOS runner (`macos-latest`) runs on Apple Silicon (arm64), which does not provide prebuilt binaries for older Node.js versions. The Intel-based `macos-13` runner is no longer available.
+
 ## Format support now
 
 * `%d` - integer


### PR DESCRIPTION
Expand CI from ubuntu-only to 3 OS matrix. Node.js versions updated to 14.x~22.x (removed unsupported 4.x~10.x).