### PR TITLE
release: v1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scanf",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "coveralls": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "C like scanf/sscanf module for node.js.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Bump version to 1.2.1 — patch release for gets() fd leak fix (#49).